### PR TITLE
passthrough column fix

### DIFF
--- a/models/intermediate/field_history/int_jira__daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__daily_field_history.sql
@@ -28,7 +28,7 @@ limit_to_relevant_fields as (
     where 
     lower(field_name) in ('sprint', 'status' 
                                 {%- for col in var('issue_field_history_columns', []) -%}
-                                , {{ "'" ~ col ~ "'" }}
+                                , {{ "'" ~ (col|lower) ~ "'" }}
                                 {%- endfor -%} )
     
 ),

--- a/models/intermediate/field_history/int_jira__pivot_daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__pivot_daily_field_history.sql
@@ -30,7 +30,7 @@ pivot_out as (
 
         {% for col in var('issue_field_history_columns', []) -%}
         ,
-            max(case when lower(field_name) = '{{ col | lower }}' then field_value end) as {{ col | replace(' ', '_') }}
+            max(case when lower(field_name) = '{{ col | lower }}' then field_value end) as {{ col | replace(' ', '_') | lower }}
         {% endfor -%}
 
     from daily_field_history


### PR DESCRIPTION
Issue: currently, when users provide columns to the `issue_field_history_columns` variable, they need to be in lower-case, otherwise the values will all show up as nulls.

Fix: convert any columns specified in `issue_field_history_columns` to lower-case when grabbing the fields.