### PR TITLE
Add ability to disable sprints and disable issue comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ vars:
 
 > Note: `sprint` and `status` will always be tracked, as they are necessary for creating common agile reports. 
 
+
+### Disabling models
+
+It's possible that your Jira connector does not sync every table that this package expects. If your syncs exclude certain tables, it is because you either don't use that functionality in Jira or actively excluded some tables from your syncs. To disable the corresponding functionality in the package, you must add the relevant variables. By default, all variables are assumed to be `true`. Add variables for only the tables you would like to disable:  
+
+```yml
+# dbt_project.yml
+
+...
+config-version: 2
+
+vars:
+  jira_source:
+    using_sprints: false # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
+  jira:
+    using_sprints: false # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
+    include_comments: false # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
+```
+
 ## Contributions
 Don't see a model or specific metric you would have liked to be included? Notice any bugs when installing 
 and running the package? If so, we highly encourage and welcome contributions to this package! 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,8 @@ It's possible that your Jira connector does not sync every table that this packa
 config-version: 2
 
 vars:
-  jira_source:
-    using_sprints: false # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
-  jira:
-    using_sprints: false # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
-    include_comments: false # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
+  jira_using_sprints: false # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
+  jira_include_comments: false # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
 ```
 
 ## Contributions

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,7 +9,6 @@ vars:
   jira:
     issue: "{{ ref('stg_jira__issue') }}"
     project: "{{ ref('stg_jira__project') }}"
-    board: "{{ ref('stg_jira__board') }}"
     user: "{{ ref('stg_jira__user') }}"
     issue_type: "{{ ref('stg_jira__issue_type') }}"
     status: "{{ ref('stg_jira__status') }}"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -21,8 +21,8 @@ vars:
     component: "{{ ref('stg_jira__component') }}"
     field: "{{ ref('stg_jira__field') }}"
     sprint: "{{ ref('stg_jira__sprint') }}"
-    include_comments: true  # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
-    using_sprints: true # disable if you are not using sprints in Jira
+    jira_include_comments: true  # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
+    jira_using_sprints: true # disable if you are not using sprints in Jira
 
 models:
   jira:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -22,6 +22,8 @@ vars:
     component: "{{ ref('stg_jira__component') }}"
     field: "{{ ref('stg_jira__field') }}"
     sprint: "{{ ref('stg_jira__sprint') }}"
+    include_comments: true  # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
+    using_sprints: true # disable if you are not using sprints in Jira
 
 models:
   jira:

--- a/integration_tests/data/board.csv
+++ b/integration_tests/data/board.csv
@@ -1,3 +1,0 @@
-id,_fivetran_synced,name,type
-5,2020-11-22 12:20:59.7,TNGP board,simple
-7,2020-11-22 12:20:57.515,SSP board,scrum

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -90,6 +90,9 @@ seeds:
     sprint: 
       +column_types:
         id: "{{ 'int64' if target.name == 'bigquery' else 'bigint' }}"
+        complete_date: timestamp
+        end_date: timestamp
+        start_date: timestamp
     field: 
       +column_types:
         id: "{{ 'string' if target.name == 'bigquery' else 'varchar' }}"

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -6,7 +6,6 @@ profile: 'integration_tests'
 
 vars:
   jira_source:
-    board: "{{ ref('board') }}"
     comment: "{{ ref('comment') }}"
     component: "{{ ref('component') }}"
     epic: "{{ ref('epic') }}"

--- a/models/intermediate/int_jira.yml
+++ b/models/intermediate/int_jira.yml
@@ -81,6 +81,14 @@ models:
         description: Title of the issue's sprint.
       - name: count_sprint_changes
         description: The total number of sprints that the issue has belonged to.
+      - name: is_active_sprint
+        description: Yes, if the sprint started after the current time and if the sprint ends in the future.
+      - name: sprint_completed_at
+        description: Timestamp of when the sprint was completed.
+      - name: sprint_ended_at
+        description: Timestamp of when the sprint is planned to end.
+      - name: sprint_started_at
+        description: Timestamp of when the sprint began. 
       - name: original_estimate_seconds
         description: The original estimate of how long working on this issue would take, in seconds.
       - name: remaining_estimate_seconds

--- a/models/intermediate/int_jira__issue_comments.sql
+++ b/models/intermediate/int_jira__issue_comments.sql
@@ -1,4 +1,4 @@
-{{ config(enabled=var('include_comments', True)) }}
+{{ config(enabled=var('jira_include_comments', True)) }}
 
 with comment as (
 

--- a/models/intermediate/int_jira__issue_comments.sql
+++ b/models/intermediate/int_jira__issue_comments.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('include_comments', True)) }}
+
 with comment as (
 
     select *

--- a/models/intermediate/int_jira__issue_join.sql
+++ b/models/intermediate/int_jira__issue_join.sql
@@ -69,6 +69,10 @@ join_issue as (
         issue_sprint.sprint_id,
         issue_sprint.sprint_name,
         issue_sprint.count_sprint_changes,
+        issue_sprint.sprint_started_at,
+        issue_sprint.sprint_ended_at,
+        issue_sprint.sprint_completed_at,
+        issue_sprint.count_sprint_changes,
         {% endif %}
 
         {% if var('include_comments', True) %}

--- a/models/intermediate/int_jira__issue_join.sql
+++ b/models/intermediate/int_jira__issue_join.sql
@@ -29,17 +29,21 @@ priority as (
     from {{ var('priority') }}
 ),
 
+{% if var('using_sprints', True) %}
 issue_sprint as (
 
     select *
     from {{ ref('int_jira__issue_sprint') }}
 ),
+{% endif %}
 
+{% if var('include_comments', True) %}
 issue_comments as (
 
     select * 
     from {{ ref('int_jira__issue_comments') }}
 ),
+{% endif %}
 
 issue_assignments_and_resolutions as (
   
@@ -61,13 +65,17 @@ join_issue as (
 
         priority.priority_name as current_priority,
 
+        {% if var('using_sprints', True) %}
         issue_sprint.sprint_id,
         issue_sprint.sprint_name,
         issue_sprint.count_sprint_changes,
+        {% endif %}
 
+        {% if var('include_comments', True) %}
         issue_comments.conversation,
         issue_comments.count_comments,
-        
+        {% endif %}
+
         issue_assignments_and_resolutions.first_assigned_at,
         issue_assignments_and_resolutions.last_assigned_at,
         issue_assignments_and_resolutions.first_resolved_at 
@@ -77,10 +85,15 @@ join_issue as (
     left join status on status.status_id = issue.status_id
     left join resolution on resolution.resolution_id = issue.resolution_id
     left join priority on priority.priority_id = issue.priority_id
-    left join issue_sprint on issue_sprint.issue_id = issue.issue_id
-    left join issue_comments on issue_comments.issue_id = issue.issue_id
     left join issue_assignments_and_resolutions on issue_assignments_and_resolutions.issue_id = issue.issue_id
+    
+    {% if var('using_sprints', True) %}
+    left join issue_sprint on issue_sprint.issue_id = issue.issue_id
+    {% endif %}
 
+    {% if var('include_comments', True) %}
+    left join issue_comments on issue_comments.issue_id = issue.issue_id
+    {% endif %}
 )
 
 select * 

--- a/models/intermediate/int_jira__issue_join.sql
+++ b/models/intermediate/int_jira__issue_join.sql
@@ -72,6 +72,8 @@ join_issue as (
         issue_sprint.sprint_started_at,
         issue_sprint.sprint_ended_at,
         issue_sprint.sprint_completed_at,
+        issue_sprint.sprint_started_at <= {{ dbt_utils.current_timestamp() }}
+          and issue_sprint.sprint_ended_at >= {{ dbt_utils.current_timestamp() }} as is_active_sprint,
         {% endif %}
 
         {% if var('include_comments', True) %}

--- a/models/intermediate/int_jira__issue_join.sql
+++ b/models/intermediate/int_jira__issue_join.sql
@@ -72,7 +72,6 @@ join_issue as (
         issue_sprint.sprint_started_at,
         issue_sprint.sprint_ended_at,
         issue_sprint.sprint_completed_at,
-        issue_sprint.count_sprint_changes,
         {% endif %}
 
         {% if var('include_comments', True) %}

--- a/models/intermediate/int_jira__issue_sprint.sql
+++ b/models/intermediate/int_jira__issue_sprint.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=var('using_sprints', True)) }}
+
 with sprint as (
 
     select * 

--- a/models/intermediate/int_jira__issue_sprint.sql
+++ b/models/intermediate/int_jira__issue_sprint.sql
@@ -1,4 +1,4 @@
-{{ config(enabled=var('using_sprints', True)) }}
+{{ config(enabled=var('jira_using_sprints', True)) }}
 
 with sprint as (
 

--- a/models/jira.yml
+++ b/models/jira.yml
@@ -94,6 +94,14 @@ models:
         description: Title of the issue's sprint.
       - name: count_sprint_changes
         description: The total number of sprints that the issue has belonged to.
+      - name: is_active_sprint
+        description: Yes, if the sprint started after the current time and if the sprint ends in the future.
+      - name: sprint_completed_at
+        description: Timestamp of when the sprint was completed.
+      - name: sprint_ended_at
+        description: Timestamp of when the sprint is planned to end.
+      - name: sprint_started_at
+        description: Timestamp of when the sprint began. 
       - name: original_estimate_seconds
         description: The original estimate of how long working on this issue would take, in seconds.
       - name: remaining_estimate_seconds

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,4 @@
 packages:
-  - package: fivetran/jira_source
-    version: 0.1.0
+  - git: https://github.com/fivetran/dbt_jira_source.git
+    revision: create_variables
+    warn-unpinned: false  

--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,4 @@
 packages:
   - git: https://github.com/fivetran/dbt_jira_source.git
-    revision: create_variables
+    revision: master
     warn-unpinned: false  

--- a/packages.yml
+++ b/packages.yml
@@ -1,4 +1,3 @@
 packages:
-  - git: https://github.com/fivetran/dbt_jira_source.git
-    revision: master
-    warn-unpinned: false  
+  - package: fivetran/jira_source
+    version: 0.1.1


### PR DESCRIPTION
This PR addresses customer requested improvements:

- Allow users to disable modeling related to Sprints. Not all Jira customers use Sprints, and therefore don't have the Sprint table.
- Allow users to disable the issue_comment aggregation. This is computationally expensive and can result in db errors.
- Allow users to disable boards (removed this table all together as it's not used in downstream models)
- Add additional sprint related fields to the final jira__issue_enhanced model. 