### PR TITLE
Add logic to allow users to disable the "components" table related models

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
             dbt deps
             dbt seed --target snowflake --full-refresh
             dbt run --target snowflake --full-refresh
+            dbt run --vars '{jira_using_sprints: false, jira_using_components: false}' --target snowflake --full-refresh
             dbt test --target snowflake
       - run:
           name: "Run Tests - BigQuery"
@@ -46,6 +47,7 @@ jobs:
             dbt deps
             dbt seed --target bigquery --full-refresh
             dbt run --target bigquery --full-refresh
+            dbt run --vars '{jira_using_sprints: false, jira_using_components: false}' --target bigquery --full-refresh
             dbt test --target bigquery
       - run:
           name: "Run Tests - Redshift"
@@ -56,6 +58,7 @@ jobs:
             dbt deps
             dbt seed --target redshift --full-refresh
             dbt run --target redshift --full-refresh
+            dbt run --vars '{jira_using_sprints: false, jira_using_components: false}' --target redshift --full-refresh
             dbt test --target redshift
       - save_cache:
           key: deps2-{{ .Branch }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ config-version: 2
 vars:
   jira_using_sprints: false # Disable if you do not have the sprint table, or if you do not want sprint related metrics reported
   jira_include_comments: false # this package aggregates issue comments so that you have a single view of all your comments in the jira__issue_enhanced table. This can cause limit errors if you have a large dataset. Disable to remove this functionality.
+  jira_using_components: false # Disable if you do not have the component table, or if you do not want component related metrics reported
 ```
 
 ## Contributions

--- a/models/jira__project_enhanced.sql
+++ b/models/jira__project_enhanced.sql
@@ -30,6 +30,8 @@ agg_epics as (
 
 ),
 
+{% if var('jira_using_components', True) %}
+
 agg_components as (
     -- i'm just aggregating the components here, but perhaps pivoting out components (and epics) 
     -- into columns where the values are the number of issues completed and/or open would be more valuable
@@ -42,6 +44,8 @@ agg_components as (
     group by 1
 ),
 
+{% endif %}
+
 project_join as (
 
     select
@@ -49,7 +53,11 @@ project_join as (
         jira_user.user_display_name as project_lead_user_name,
         jira_user.email as project_lead_email,
         agg_epics.epics,
+        
+        {% if var('jira_using_components', True) %}
         agg_components.components,
+        {% endif %}
+
         coalesce(project_metrics.count_closed_issues, 0) as count_closed_issues,
         coalesce(project_metrics.count_open_issues, 0) as count_open_issues,
         coalesce(project_metrics.count_open_assigned_issues, 0) as count_open_assigned_issues,
@@ -82,7 +90,11 @@ project_join as (
     left join project_metrics on project.project_id = project_metrics.project_id
     left join jira_user on project.project_lead_user_id = jira_user.user_id
     left join agg_epics on project.project_id = agg_epics.project_id 
+    
+    {% if var('jira_using_components', True) %}
     left join agg_components on project.project_id = agg_components.project_id 
+    {% endif %}
+
 )
 
 select * from project_join


### PR DESCRIPTION
This PR introduces the `jira_using_components` variable, which can be set to false to allow users to disable any modeling related to jira's component table. 

[Related issue ](https://github.com/fivetran/dbt_jira_source/issues/7)