### PR TITLE
Dbt compile fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check [dbt Hub](https://hub.getdbt.com/) for the latest installation instruction
 # packages.yml
 packages:
   - package: fivetran/jira
-    version: [">=0.2.0", "<0.3.0"]
+    version: [">=0.3.0", "<0.4.0"]
 ```
 
 ## Configuration

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -5,6 +5,7 @@ profile: 'integration_tests'
 
 
 vars:
+  jira_schema: jira_integration_tests
   jira_source:
     comment: "{{ ref('comment') }}"
     component: "{{ ref('component') }}"

--- a/models/intermediate/field_history/int_jira__issue_calendar_spine.sql
+++ b/models/intermediate/field_history/int_jira__issue_calendar_spine.sql
@@ -11,7 +11,7 @@ with spine as (
     {% if execute %}
     {% set first_date_query %}
     -- start at the first created issue
-        select  min( created_at ) as min_date from {{ var('issue') }}
+        select  min( created ) as min_date from {{ source('jira','issue') }}
     {% endset %}
     {% set first_date = run_query(first_date_query).columns[0][0]|string %}
     


### PR DESCRIPTION
This PR includes the following changes:

- Updates the run query logic within the `int_jira__issue_calendar_spine` model to query from the source opposed to the staging model. This is required in order to have `dbt compile` succeed prior to executing `dbt run` as the run command cannot query a table that doesn't exist. The source remedies that.
- Update to the integration tests in schema variable in order for the source to succeed.