### PR TITLE
Fix query by referring to correct CTE

### DIFF
--- a/models/intermediate/int_jira__issue_assign_resolution.sql
+++ b/models/intermediate/int_jira__issue_assign_resolution.sql
@@ -25,7 +25,7 @@ issue_dates as (
         max(case when field_id = 'assignee' then updated_at end) as last_assigned_at,
         min(case when field_id = 'resolutiondate' then updated_at end) as first_resolved_at -- in case it's been re-opened
 
-    from issue_field_history
+    from filtered
     group by 1
 )
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Thibault He, Senior BI Analyst, Onfido

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
A very tiny fix to `int_jira__issue_assign_resolution`

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide explanation how the change is non breaking below.)
It won't break anything for anybody I believe, will only make downstream models more accurate.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes, Issue [link issue number here]
- [x] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other (please provide additional testing details below)
This is what I said on the dbt Slack: if we look at first_resolved_at for instance, my understanding is that there is always going to be a row for field_id = resolutiondate even for issues that have never been resolved, but in that case the value is null. Therefore we use the filtered CTE in order to exclude those rows, otherwise we will wrongly return an actual value for first_resolved_at when this should be null for non-resolved issues

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [ ] BigQuery
- [x] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
