### PR TITLE
current_date changed to dbt_utils.current_timestamp_in_utc

### DIFF
--- a/models/intermediate/field_history/int_jira__issue_calendar_spine.sql
+++ b/models/intermediate/field_history/int_jira__issue_calendar_spine.sql
@@ -81,7 +81,7 @@ surrogate_key as (
 
     from issue_spine
 
-    where cast(date_day as {{ dbt_utils.type_timestamp() }} ) <= {{ dbt_utils.date_trunc('day',dbt_utils.current_timestamp_in_utc()) }}
+    where date_day <= cast( {{ dbt_utils.date_trunc('day',dbt_utils.current_timestamp_in_utc()) }} as date)
 )
 
 select * from surrogate_key 

--- a/models/intermediate/field_history/int_jira__issue_calendar_spine.sql
+++ b/models/intermediate/field_history/int_jira__issue_calendar_spine.sql
@@ -28,7 +28,7 @@ with spine as (
             dbt_utils.date_spine(
                 datepart = "day", 
                 start_date =  "cast('" ~ first_date[0:10] ~ "' as date)", 
-                end_date = dbt_utils.dateadd("week", 1, "current_date")
+                end_date = dbt_utils.dateadd("week", 1, dbt_utils.current_timestamp_in_utc())
             )   
         }} 
     ) as date_spine
@@ -48,7 +48,7 @@ issue_dates as (
 
         -- resolved_at will become null if an issue is marked as un-resolved. if this sorta thing happens often, you may want to run full-refreshes of the field_history models often
         -- if it's not resolved include everything up to today. if it is, look at the last time it was updated 
-        cast({{ dbt_utils.date_trunc('day', 'case when resolved_at is null then ' ~ dbt_utils.current_timestamp() ~ ' else updated_at end') }} as date) as open_until
+        cast({{ dbt_utils.date_trunc('day', 'case when resolved_at is null then ' ~ dbt_utils.current_timestamp_in_utc() ~ ' else updated_at end') }} as date) as open_until
 
     from {{ var('issue') }}
 
@@ -81,7 +81,7 @@ surrogate_key as (
 
     from issue_spine
 
-    where date_day <= current_date
+    where cast(date_day as {{ dbt_utils.type_timestamp() }} ) <= {{ dbt_utils.date_trunc('day',dbt_utils.current_timestamp_in_utc()) }}
 )
 
 select * from surrogate_key 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
This PR introduces the use of the `dbt_utils.current_timestamp_in_utc` macro in place of the `current_date` warehouse function within the `int_jira__issue_calendar_spine` model. This is due to issues some users were experiencing with the package not providing accurate date timestamps in certain regions. 

As Fivetran syncs the data in UTC it makes sense to use the UTC timezone in the calendar spine as well.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [X] Yes (please provide breaking change details below.)
- [ ] No  (please provide explanation how the change is non breaking below.)

This will need to result in a breaking change since the update is being made to the `int_jira__issue_calendar_spine` model which is incremental. As such, a `--full-refresh` will be needed to be executed by users in order for the change to be appropriately reflected in their output model.s

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [X] Yes, Issue #44 
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
⌚ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
