### PR TITLE
Bug/sprint history missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # dbt_jira v0.8.2
 ## Bug Fixes
-- Corrected bug introduced in 8.0 that would prevent `sprint` data from being passed to model `jira__daily_issue_field_history`
+- Corrected bug introduced in 0.8.0 that would prevent `sprint` data from being passed to model `jira__daily_issue_field_history`. ([#62](https://github.com/fivetran/dbt_jira/pull/62))
+
 
 ## Contributors
-- @troyschuetrumpf-elation
+- [@troyschuetrumpf-elation](https://github.com/troyschuetrumpf-elation) ([#62](https://github.com/fivetran/dbt_jira/pull/62))
 
 # dbt_jira v0.8.1
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_jira v0.8.2
+## Bug Fixes
+- Corrected bug introduced in 8.0 that would prevent `sprint` data from being passed to model `jira__daily_issue_field_history`
+
+## Contributors
+- @troyschuetrumpf-elation
+
 # dbt_jira v0.8.1
 ## Features
 - Makes priority data optional. Allows new env var `jira_using_priorities`. Models `jira__issue_enhanced` and `int_jira__issue_join` won't require source `jira.priority` or contain priority-related columns if `jira_using_priorities: false`. ([#55](https://github.com/fivetran/dbt_jira/pull/55))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'jira'
-version: '0.8.1'
+version: '0.8.2'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'jira_integration_tests'
-version: '0.8.1'
+version: '0.8.2'
 config-version: 2
 profile: 'integration_tests'
 

--- a/models/intermediate/field_history/int_jira__daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__daily_field_history.sql
@@ -28,8 +28,9 @@ limit_to_relevant_fields as (
 
     from combined_field_histories
 
-    where lower(field_id) = 'status' -- As sprint is a custom field, we filter by field name only for sprint. All others are on field_id.
-        or lower(field_name) in ('sprint'
+    where lower(field_name) in 
+            ('sprint'
+            ,'status'
             {%- for col in var('issue_field_history_columns', []) -%}
                 ,'{{ (col|lower) }}'
             {%- endfor -%} )

--- a/models/intermediate/field_history/int_jira__daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__daily_field_history.sql
@@ -29,7 +29,7 @@ limit_to_relevant_fields as (
     from combined_field_histories
 
     where lower(field_id) = 'status' -- As sprint is a custom field, we filter by field name only for sprint. All others are on field_id.
-        or lower(field_name) in ('status'
+        or lower(field_name) in ('sprint'
             {%- for col in var('issue_field_history_columns', []) -%}
                 ,'{{ (col|lower) }}'
             {%- endfor -%} )

--- a/models/intermediate/field_history/int_jira__daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__daily_field_history.sql
@@ -29,8 +29,8 @@ limit_to_relevant_fields as (
     from combined_field_histories
 
     where lower(field_name) in 
-            ('sprint'
-            ,'status'
+            ('status'
+            ,'sprint'
             {%- for col in var('issue_field_history_columns', []) -%}
                 ,'{{ (col|lower) }}'
             {%- endfor -%} )

--- a/models/intermediate/field_history/int_jira__daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__daily_field_history.sql
@@ -28,9 +28,8 @@ limit_to_relevant_fields as (
 
     from combined_field_histories
 
-    where lower(field_name) in 
-            ('status'
-            ,'sprint'
+    where lower(field_id) = 'status' 
+            or lower(field_name) in ('sprint'
             {%- for col in var('issue_field_history_columns', []) -%}
                 ,'{{ (col|lower) }}'
             {%- endfor -%} )

--- a/models/intermediate/field_history/int_jira__pivot_daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__pivot_daily_field_history.sql
@@ -28,7 +28,7 @@ pivot_out as (
     select 
         valid_starting_on, 
         issue_id,
-        max(case when lower(field_name) = 'status' then field_value end) as status,
+        max(case when lower(field_id) = 'status' then field_value end) as status,
         max(case when lower(field_name) = 'sprint' then field_value end) as sprint
 
         {% for col in var('issue_field_history_columns', []) -%}

--- a/models/intermediate/field_history/int_jira__pivot_daily_field_history.sql
+++ b/models/intermediate/field_history/int_jira__pivot_daily_field_history.sql
@@ -28,8 +28,8 @@ pivot_out as (
     select 
         valid_starting_on, 
         issue_id,
-        max(case when lower(field_id) = 'status' then field_value end) as status,
-        max(case when lower(field_name) = 'sprint' then field_value end) as sprint -- As sprint is a custom field, we aggregate on the field_name.
+        max(case when lower(field_name) = 'status' then field_value end) as status,
+        max(case when lower(field_name) = 'sprint' then field_value end) as sprint
 
         {% for col in var('issue_field_history_columns', []) -%}
         ,


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Troy Schuetrumpf, VP Platform Engineering, Elation Health

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
Bug introduced in 8.0. This PR resolves the introduced bug and updates the `status` selection to use field_name (I verified that this is how this columns ID and Name are represented in jira)

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

This will cause the status column of `jira__daily_issue_field_history` to be populated with data again. No column names or functionality changed.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature [link bug/feature number here]
- [ ] No 
https://github.com/fivetran/dbt_jira/issues/61

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

Updated our dbt project that is built on fivetran jira data to use the updated models, run against our dataset and observed sprint column populated with data.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [x] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
👍 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
