### PR TITLE
use left join for joining current sprint info 

### DIFF
--- a/models/intermediate/int_jira__issue_sprint.sql
+++ b/models/intermediate/int_jira__issue_sprint.sql
@@ -9,7 +9,6 @@ with sprint as (
 
 field_history as (
 
-     -- sprints don't appear to be capable of multiselect in the UI...
     select *
     from {{ ref('int_jira__issue_multiselect_history') }}
 
@@ -25,7 +24,7 @@ sprint_field_history as (
                     order by field_history.updated_at desc, sprint.started_at desc         
                     ) as row_num
     from field_history
-    join sprint on field_history.field_value = cast(sprint.sprint_id as {{ dbt.type_string() }})
+    left join sprint on field_history.field_value = cast(sprint.sprint_id as {{ dbt.type_string() }})
     where lower(field_history.field_name) = 'sprint'
 ),
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
internal

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
- makes the join [here](https://github.com/fivetran/dbt_jira/blob/main/models/intermediate/int_jira__issue_sprint.sql#L28) a left join. this is necessary when the latest sprint value is truly `null`

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes
not yet

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Yes, Issue/Feature https://github.com/fivetran/dbt_jira/issues/91
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] Buildkite). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [x] Buildkite <!--- Buildkite testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🧨 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
