### PR TITLE
Support DuckDB percentile medians

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# dbt_jira v1.8.1
+
+## Bug Fix
+- Adds DuckDB support for median issue metrics by using the aggregate percentile path already used by Postgres. This prevents DuckDB from receiving the unsupported `percentile_cont(...) within group (...) over (...)` window form.
+
 # dbt_jira v1.8.0
 
 [PR #182](https://github.com/fivetran/dbt_jira/pull/180) includes the following updates:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ This dbt package is dependent on the following dbt packages. These dependencies 
 ```yml
 packages:
     - package: fivetran/fivetran_utils
-      version: [">=0.4.0", "<0.5.0"]
+      version: [">=0.4.12", "<0.5.0"]
 
     - package: dbt-labs/dbt_utils
       version: [">=1.0.0", "<2.0.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'jira'
-version: '1.8.0'
+version: '1.8.1'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<3.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'jira_integration_tests'
-version: '1.8.0'
+version: '1.8.1'
 config-version: 2
 profile: 'integration_tests'
 

--- a/models/intermediate/int_jira__project_metrics.sql
+++ b/models/intermediate/int_jira__project_metrics.sql
@@ -20,10 +20,10 @@ calculate_medians as (
                     partition_field='project_id', percent='0.5') }} as {{ dbt.type_numeric() }} ), 0) as median_age_currently_open_assigned_seconds
     from issue
 
-    {% if target.type == 'postgres' %} group by project_id, source_relation {% endif %}
+    {% if target.type in ('postgres', 'duckdb') %} group by project_id, source_relation {% endif %}
 ),
 
--- grouping because the medians were calculated using window functions (except in postgres)
+-- grouping because the medians were calculated using window functions (except in postgres and duckdb)
 median_metrics as (
 
     select

--- a/models/intermediate/int_jira__user_metrics.sql
+++ b/models/intermediate/int_jira__user_metrics.sql
@@ -15,10 +15,10 @@ calculate_medians as (
         round(cast({{ fivetran_utils.percentile(percentile_field='case when resolved_at is null then last_assignment_duration_seconds end',
                     partition_field='assignee_user_id', percent='0.5') }} as {{ dbt.type_numeric() }}), 0) as median_age_currently_open_seconds
     from issue
-    {% if target.type == 'postgres' %} group by 1, 2 {% endif %}
+    {% if target.type in ('postgres', 'duckdb') %} group by 1, 2 {% endif %}
 ),
 
--- grouping because the medians were calculated using window functions (except postgres)
+-- grouping because the medians were calculated using window functions (except postgres and duckdb)
 median_metrics as (
 
     select

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
 - package: fivetran/fivetran_utils
-  version: [">=0.4.0", "<0.5.0"]
+  version: [">=0.4.12", "<0.5.0"]
 
 - package: dbt-labs/spark_utils
   version: [">=0.3.0", "<0.4.0"]


### PR DESCRIPTION
*Please provide your name and company*

Yahia Mostafa, MotherDuck.

**Link the issue/feature request which this PR is meant to address**

No public issue yet. This addresses a DuckDB compatibility issue in the Jira package’s median metric models.

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

This PR updates the Jira median metric models so DuckDB uses the grouped aggregate percentile path already used by Postgres.  Depends on [fivetran/dbt_fivetran_utils#155](https://github.com/fivetran/dbt_fivetran_utils/pull/155), which adds the DuckDB dispatch for `fivetran_utils.percentile`.

DuckDB supports `percentile_cont(...) within group (order by ...)` as an aggregate, but does not support the Redshift-style `percentile_cont(...) within group (...) over (...)` window form emitted through the default `fivetran_utils.percentile` dispatch.

This PR:
  - Adds DuckDB to the grouped median CTE condition in user metrics.
  - Adds DuckDB to the grouped median CTE condition in project metrics.
  - Updates the `fivetran_utils` dependency floor to a version that includes `duckdb__percentile`.
  - Updates changelog, package versions, and dependency documentation.

**How did you validate the changes introduced within this PR?**

Validated against DuckDB:
  - Aggregate form succeeds: `percentile_cont(0.5) within group (order by x)`.
  - Windowed ordered-set form fails with `Catalog Error: Aggregate Function with name percentile_cont does not exist!`, matching the reported failure.
  - A grouped Jira-style median query returns expected per-user medians.

Also ran `git diff --check`.

**Which warehouse did you use to develop these changes?**

  DuckDB/MotherDuck.

**Did you update the CHANGELOG?**

  - [x] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**

  - [x] Yes

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**

  - [x] Yes
  - [ ] No

  **If you had to summarize this PR in an emoji, which would it be?**

  :duck: