### PR TITLE
docs: highlight automatic field label resolution benefit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,7 @@ This dbt package transforms data from Fivetran's Jira connector into analytics-r
   - `>=1.3.0, <3.0.0`
 
 ## What does this dbt package do?
-This package enables you to better understand the workload, performance, and velocity of your team's work using Jira issues. It creates enriched models with metrics focused on daily issue history, workflow analysis, and team performance.
-
-### Automatic field label resolution
-Jira's raw synced data stores field values as IDs. For example, the `ISSUE` table contains a `status` value of `10005` rather than the human-readable label `In Progress`. To build reports from raw data, you would need to manually join across dimension tables like `STATUS`, `PRIORITY`, `RESOLUTION`, `SPRINT`, and `FIELD_OPTION` to retrieve the display names your team actually recognizes.
-
-This package handles all of those joins for you. The enhanced models resolve both standard and custom field IDs to their label values automatically, so you can query results like `status = 'In Progress'` or `priority = 'High'` directly without writing any join logic yourself. This applies to:
-- **Standard fields**: status, priority, resolution, issue type, project, sprint name, assignee, and reporter names
-- **Custom fields**: select lists, multi-select fields, radio buttons, cascading selects, and other fields tracked through the `FIELD_OPTION` table
-- **Historical values**: the daily and timestamp field history models also resolve labels, so you can analyze how fields changed over time using readable names rather than IDs
+This package enables you to better understand the workload, performance, and velocity of your team's work using Jira issues. It creates enriched models with metrics focused on daily issue history, workflow analysis, and team performance. The package also resolves IDs to their human-readable labels across standard fields, custom fields, and historical values, so you can query `status = 'In Progress'` instead of `status = 10005` without writing any join logic yourself.
 
 ### Output schema
 Final output tables are generated in the following target schema:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ This dbt package transforms data from Fivetran's Jira connector into analytics-r
 ## What does this dbt package do?
 This package enables you to better understand the workload, performance, and velocity of your team's work using Jira issues. It creates enriched models with metrics focused on daily issue history, workflow analysis, and team performance.
 
+### Automatic field label resolution
+Jira's raw synced data stores field values as IDs. For example, the `ISSUE` table contains a `status` value of `10005` rather than the human-readable label `In Progress`. To build reports from raw data, you would need to manually join across dimension tables like `STATUS`, `PRIORITY`, `RESOLUTION`, `SPRINT`, and `FIELD_OPTION` to retrieve the display names your team actually recognizes.
+
+This package handles all of those joins for you. The enhanced models resolve both standard and custom field IDs to their label values automatically, so you can query results like `status = 'In Progress'` or `priority = 'High'` directly without writing any join logic yourself. This applies to:
+- **Standard fields**: status, priority, resolution, issue type, project, sprint name, assignee, and reporter names
+- **Custom fields**: select lists, multi-select fields, radio buttons, cascading selects, and other fields tracked through the `FIELD_OPTION` table
+- **Historical values**: the daily and timestamp field history models also resolve labels, so you can analyze how fields changed over time using readable names rather than IDs
+
 ### Output schema
 Final output tables are generated in the following target schema:
 


### PR DESCRIPTION
**Please provide your name and company**

Alexander Ilyichov, Fivetran

**Link the issue/feature request which this PR is meant to address**

[RD-1179372](https://fivetran.atlassian.net/browse/RD-1179372) — Update Jira docs to highlight data model benefits.

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

Adds an "Automatic field label resolution" section to the README (within the `jira_transformation_model` section that renders on the docs site). This section explains that:

- Raw Jira synced data stores field values as IDs, requiring manual joins to dimension tables
- The data models automatically resolve both standard and custom field IDs to human-readable label values
- This applies to standard fields (status, priority, resolution, etc.), custom fields (select lists, multi-selects, etc.), and historical field values

The goal is to highlight this as a key adoption driver for the Jira data models, since it removes the most tedious part of working with raw Jira data.

**How did you validate the changes introduced within this PR?**

Content-only change (README documentation). Verified the addition is within the `<!--section="jira_transformation_model"-->` markers so it will render on the docs site.

**Which warehouse did you use to develop these changes?**

N/A — documentation only.

**Did you update the CHANGELOG?**

- [ ] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**

- [ ] Yes

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**

- [x] Yes
- [ ] No

**If you had to summarize this PR in an emoji, which would it be?**

:label:

🤖 Generated with [Claude Code](https://claude.com/claude-code)